### PR TITLE
docs: Don't suggest to use version ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ dependencies {
 
     // It is recommended to also include the latest Maps SDK, Places SDK and RxJava so you
     // have the latest features and bug fixes.
-    implementation 'com.google.android.gms:play-services-maps:+'
-    implementation 'com.google.android.libraries.places:places:+'
-    implementation 'io.reactivex.rxjava3:rxjava:+'
+    implementation 'com.google.android.gms:play-services-maps:<insert-latest-version>'
+    implementation 'com.google.android.libraries.places:places:<insert-latest-version>'
+    implementation 'io.reactivex.rxjava3:rxjava:<insert-latest-version>'
 }
 ```
 


### PR DESCRIPTION
Version ranges are problematic because they lead to unreproducible builds,
unless you also use dependency lock properly, which many projects don't.
Furthermore, this triggers a warning in the IDE (for a good reason, the one mentioned above).