### PR TITLE
chore: changed secrets name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,8 @@ jobs:
         GPG_KEY_ARMOR: "${{ secrets.SYNCED_GPG_KEY_ARMOR }}"
         GPG_KEY_ID: ${{ secrets.SYNCED_GPG_KEY_ID }}
         GPG_PASSWORD: ${{ secrets.SYNCED_GPG_KEY_PASSWORD }}
-        SONATYPE_PASSWORD: ${{ secrets.SYNCED_SONATYPE_PASSWORD }}
-        SONATYPE_USERNAME: ${{ secrets.SYNCED_SONATYPE_USERNAME }}
+        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}
+        SONATYPE_USERNAME: ${{ secrets.SONATYPE_TOKEN }}
     - name: Semantic Release
       uses: cycjimmy/semantic-release-action@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,10 @@ jobs:
     - name: Gradle Wrapper Validation
       uses: gradle/wrapper-validation-action@v1.0.4
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
 
     - name: Build modules

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,16 +1,21 @@
 plugins {
     id 'com.android.application'
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
     id 'kotlin-android'
-    id 'com.google.android.secrets-gradle-plugin' version '1.1.0'
 }
 
 android {
-    compileSdkVersion 31
+    buildFeatures {
+        buildConfig = true
+    }
+
+    compileSdk 34
+    namespace = "com.google.maps.android.rx.demo"
 
     defaultConfig {
         applicationId "com.google.maps.android.rx.demo"
         minSdkVersion 24
-        targetSdkVersion 31
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     // It is recommended to also include the latest Maps SDK, Places SDK and RxJava so you
     // have the latest features and bug fixes.
     implementation "com.google.android.gms:play-services-maps:18.0.2"
-    implementation 'com.google.android.libraries.places:places:2.5.0'
+    implementation 'com.google.android.libraries.places:places:4.0.0'
     implementation 'io.reactivex.rxjava3:rxjava:3.1.4'
 
     //implementation project(":maps-rx")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,10 +23,11 @@ buildscript {
         maven(url = "https://plugins.gradle.org/m2/")
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.2.2")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21")
+        classpath("com.android.tools.build:gradle:8.7.1")
+        classpath("com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.5.0")
-        classpath("com.hiya:jacoco-android:0.2")
+        classpath("com.mxalbert.gradle:jacoco-android:0.2.1")
     }
 }
 
@@ -56,13 +57,27 @@ subprojects {
     apply(plugin = "maven-publish")
     apply(plugin = "org.jetbrains.dokka")
     apply(plugin = "signing")
-    apply(plugin = "com.hiya.jacoco-android")
+    apply(plugin = "com.mxalbert.gradle.jacoco-android")
+
 
     val sourcesJar = task<Jar>("sourcesJar") {
         archiveClassifier.set("sources")
         val libraryExtension = (project.androidExtension as com.android.build.gradle.LibraryExtension)
         from(libraryExtension.sourceSets["main"].java.srcDirs)
     }
+
+    configure<JacocoPluginExtension> {
+        toolVersion = "0.8.7"
+
+    }
+
+    tasks.withType<Test>().configureEach {
+        extensions.configure<JacocoTaskExtension> {
+            isIncludeNoLocationClasses = true
+            excludes = listOf("jdk.internal.*")
+        }
+    }
+
 
     val dokkaHtml = tasks.named<org.jetbrains.dokka.gradle.DokkaTask>("dokkaHtml")
     val dokkaJavadoc = tasks.named<org.jetbrains.dokka.gradle.DokkaTask>("dokkaJavadoc")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 22 14:51:15 PST 2021
+#Wed Oct 16 17:13:36 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/maps-rx/build.gradle
+++ b/maps-rx/build.gradle
@@ -1,5 +1,5 @@
 android {
-    namespace = "com.google.maps.android.rx"
+    namespace = "com.google.maps.android.rx.maps"
 
     compileSdk 34
 

--- a/maps-rx/build.gradle
+++ b/maps-rx/build.gradle
@@ -1,9 +1,11 @@
 android {
-    compileSdkVersion 30
+    namespace = "com.google.maps.android.rx"
+
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 30
+        targetSdkVersion 35
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }

--- a/maps-rx/src/main/AndroidManifest.xml
+++ b/maps-rx/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
  limitations under the License.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.maps.android.rx.maps">
+<manifest>
 
 </manifest>

--- a/places-rx/build.gradle
+++ b/places-rx/build.gradle
@@ -1,5 +1,5 @@
 android {
-    namespace = "com.google.maps.android.rx"
+    namespace = "com.google.maps.android.rx.places"
 
     compileSdk 34
 

--- a/places-rx/build.gradle
+++ b/places-rx/build.gradle
@@ -1,9 +1,11 @@
 android {
-    compileSdkVersion 30
+    namespace = "com.google.maps.android.rx"
+
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 30
+        targetSdkVersion 35
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }

--- a/places-rx/src/main/AndroidManifest.xml
+++ b/places-rx/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.maps.android.rx.places">
+<manifest>
 
 </manifest>

--- a/places-rx/src/main/java/com/google/maps/android/rx/places/internal/MainThreadTaskSingle.kt
+++ b/places-rx/src/main/java/com/google/maps/android/rx/places/internal/MainThreadTaskSingle.kt
@@ -7,7 +7,7 @@ import io.reactivex.rxjava3.core.SingleObserver
 /**
  * A subclass of [Single] to be used for wrapping a [Task]
  */
-internal abstract class MainThreadTaskSingle<T> : MainThreadSingle<T>() {
+internal abstract class MainThreadTaskSingle<T : Any> : MainThreadSingle<T>() {
     override fun subscribeMainThread(observer: SingleObserver<in T>) {
         val cancellationTokenSource = CancellationTokenSource()
         val listener = TaskCompletionListener(cancellationTokenSource, observer)

--- a/places-rx/src/main/java/com/google/maps/android/rx/places/internal/TaskCompletionListener.kt
+++ b/places-rx/src/main/java/com/google/maps/android/rx/places/internal/TaskCompletionListener.kt
@@ -9,7 +9,7 @@ import io.reactivex.rxjava3.core.SingleObserver
 /**
  * A listener for completion events from a [Task] that emits results to a [SingleObserver].
  */
-internal class TaskCompletionListener<T>(
+internal class TaskCompletionListener<T : Any>(
     val cancellationTokenSource: CancellationTokenSource,
     private val observer: SingleObserver<in T>
 ) : MainThreadDisposable(), OnCompleteListener<T> {

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -4,11 +4,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    namespace = "com.google.maps.android.rx.shared"
+
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 30
+        targetSdkVersion 35
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }

--- a/shared/src/main/AndroidManifest.xml
+++ b/shared/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.maps.android.rx.shared">
+<manifest>
 
 </manifest>

--- a/shared/src/main/java/com/google/maps/android/rx/shared/MainThreadMaybe.kt
+++ b/shared/src/main/java/com/google/maps/android/rx/shared/MainThreadMaybe.kt
@@ -22,7 +22,7 @@ import io.reactivex.rxjava3.disposables.Disposable
 /**
  * A Single that enforces that subscriptions occur on the Android main thread.
  */
-public abstract class MainThreadMaybe<T> : Maybe<T>() {
+public abstract class MainThreadMaybe<T : Any> : Maybe<T>() {
     override fun subscribeActual(observer: MaybeObserver<in T>) {
         if (Looper.myLooper() != Looper.getMainLooper()) {
             observer.onSubscribe(Disposable.empty())

--- a/shared/src/main/java/com/google/maps/android/rx/shared/MainThreadObservable.kt
+++ b/shared/src/main/java/com/google/maps/android/rx/shared/MainThreadObservable.kt
@@ -22,7 +22,7 @@ import io.reactivex.rxjava3.disposables.Disposable
 /**
  * An Observable that enforces that subscriptions occur on the Android main thread.
  */
-public abstract class MainThreadObservable<T> : Observable<T>() {
+public abstract class MainThreadObservable<T : Any> : Observable<T>() {
     override fun subscribeActual(observer: Observer<in T>) {
         if (Looper.myLooper() != Looper.getMainLooper()) {
             observer.onSubscribe(Disposable.empty())

--- a/shared/src/main/java/com/google/maps/android/rx/shared/MainThreadSingle.kt
+++ b/shared/src/main/java/com/google/maps/android/rx/shared/MainThreadSingle.kt
@@ -22,7 +22,7 @@ import io.reactivex.rxjava3.disposables.Disposable
 /**
  * A Single that enforces that subscriptions occur on the Android main thread.
  */
-public abstract class MainThreadSingle<T> : Single<T>() {
+public abstract class MainThreadSingle<T : Any> : Single<T>() {
 
     override fun subscribeActual(observer: SingleObserver<in T>) {
         if (Looper.myLooper() != Looper.getMainLooper()) {


### PR DESCRIPTION
This PR updates the name of the Sonatype secrets.

It also performs some maintenance work to keep the repository running on the current Android Studio version (namely, AGP updates, Kotlin, Gradle, targetSdk, as well as some updates on the build script)