### PR TITLE
chore: added Lint report

### DIFF
--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -1,0 +1,49 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Lint and Upload SARIF
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+
+      - name: Run Android Lint
+        run: ./gradlew lint
+
+      - name: Merge SARIF files
+        run: |
+          jq -s '{ "$schema": "https://json.schemastore.org/sarif-2.1.0", "version": "2.1.0", "runs": map(.runs) | add }'  shared/build/reports/lint-results.sarif  places-rx/build/reports/lint-results.sarif  maps-rx/build/reports/lint-results.sarif  app/build/reports/lint-results.sarif > merged.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: merged.sarif

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,10 @@ plugins {
 }
 
 android {
+    lint {
+        sarifOutput = file("$buildDir/reports/lint-results.sarif")
+    }
+
     compileSdkVersion 31
 
     defaultConfig {

--- a/maps-rx/build.gradle
+++ b/maps-rx/build.gradle
@@ -1,4 +1,8 @@
 android {
+    lint {
+        sarifOutput = file("$buildDir/reports/lint-results.sarif")
+    }
+
     compileSdkVersion 30
 
     defaultConfig {

--- a/places-rx/build.gradle
+++ b/places-rx/build.gradle
@@ -1,4 +1,8 @@
 android {
+    lint {
+        sarifOutput = file("$buildDir/reports/lint-results.sarif")
+    }
+
     compileSdkVersion 30
 
     defaultConfig {

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -4,6 +4,9 @@ plugins {
 }
 
 android {
+    lint {
+        sarifOutput = file("$buildDir/reports/lint-results.sarif")
+    }
     namespace = "com.google.maps.android.rx.shared"
 
     compileSdk 34


### PR DESCRIPTION
The following PR adds a Lint report, generates the SARIF files and upload them to GitHub, so we can get Lint reports on each PR and activate GitHub Code scanning alerts.

The [PR updating the secret names and doing some housekeeping](https://github.com/googlemaps/android-maps-rx/pull/131) should be merged first. The repository is a bit old, and we needed to upgrade it.