### PR TITLE
chore: remove branches file from test flow in gh-pages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,8 @@ on:
   repository_dispatch:
     types: [test]
   pull_request:
-    branches: ['*']
     branches-ignore: ['gh-pages']
   push:
-    branches: ['*']
     branches-ignore: ['gh-pages']
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ on:
   repository_dispatch:
     types: [test]
   pull_request:
-    branches-ignore: ['gh-pages']
+    branches-ignore: ['gh-pages', 'googlemaps-bot/update_gh_pages']
   push:
-    branches-ignore: ['gh-pages']
+    branches-ignore: ['gh-pages', 'googlemaps-bot/update_gh_pages']
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The following PR removes [an error triggered](https://github.com/googlemaps/android-maps-rx/actions/runs/12088528149/workflow) when generating the documentation, since we have both branches and branches-ignore on the configuration file, which is not allowed:

![Screenshot 2024-11-29 at 18 35 43](https://github.com/user-attachments/assets/c2807b11-92bb-405d-91d9-4e3213ae5fe8)
