### PR TITLE
chore: migrated new Maven Central URL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,7 +138,7 @@ subprojects {
         repositories {
             maven {
                 name = "mavencentral"
-                url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+                url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
                 credentials {
                     username = properties["sonatypeUsername"] as String?
                     password = properties["sonatypePassword"] as String


### PR DESCRIPTION
This draft PR migrates the URL required to push onto the new Maven Central. More information about it:

https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/