### PR TITLE
chore: fix SARIF upload by splitting per category

### DIFF
--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -39,11 +39,26 @@ jobs:
       - name: Run Android Lint
         run: ./gradlew lint
 
-      - name: Merge SARIF files
-        run: |
-          jq -s '{ "$schema": "https://json.schemastore.org/sarif-2.1.0", "version": "2.1.0", "runs": map(.runs) | add }'  shared/build/reports/lint-results.sarif  places-rx/build/reports/lint-results.sarif  maps-rx/build/reports/lint-results.sarif  app/build/reports/lint-results.sarif > merged.sarif
-
-      - name: Upload SARIF file
+      - name: Upload SARIF for shared
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: merged.sarif
+          sarif_file: shared/build/reports/lint-results.sarif
+          category: shared
+
+      - name: Upload SARIF for places-rx
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: places-rx/build/reports/lint-results.sarif
+          category: places-rx
+
+      - name: Upload SARIF for maps-rx
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: maps-rx/build/reports/lint-results.sarif
+          category: maps-rx
+
+      - name: Upload SARIF for app
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: app/build/reports/lint-results.sarif
+          category: app


### PR DESCRIPTION
This PR updates the workflow to upload SARIF files separately for each module (library, demo) with distinct categories.

Merging SARIF runs is [no longer supported](https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/) by GitHub Code Scanning as of mid-2025. This change ensures compatibility and removes the deprecated jq merge step.